### PR TITLE
Condi damage, use damage not DPS

### DIFF
--- a/TW5_parse_top_stats_tools.py
+++ b/TW5_parse_top_stats_tools.py
@@ -1750,7 +1750,7 @@ def get_stat_from_player_json(player_json, players_running_healing_addon, stat, 
 			return 0
 		sumDamage = 0
 		for target in player_json['dpsTargets']:
-			sumDamage = sumDamage + int(target[0]['condiDps'])
+			sumDamage = sumDamage + int(target[0]['condiDamage'])
 		return int(sumDamage)
 		#return int(player_json['dpsAll'][0]['condiDamage'])    
 	


### PR DESCRIPTION
When we switched over from using `dpsAll` we used `condiDps`, but want to use `condiDamage`