### PR TITLE
Squad Offensive stats use target, not all

### DIFF
--- a/TW5_parse_top_stats_tools.py
+++ b/TW5_parse_top_stats_tools.py
@@ -2249,9 +2249,9 @@ def get_stats_from_fight_json(fight_json, config, log):
             
 		for stat in statAll:
 			if stat not in squad_offensive[squadDps_prof_name]['stats']:
-				squad_offensive[squadDps_prof_name]['stats'][stat] = player['statsAll'][0][stat]
+				squad_offensive[squadDps_prof_name]['stats'][stat] = sum([stats[0][stat] for stats in player['statsTargets']])
 			else:
-				squad_offensive[squadDps_prof_name]['stats'][stat] += player['statsAll'][0][stat]
+				squad_offensive[squadDps_prof_name]['stats'][stat] += sum([stats[0][stat] for stats in player['statsTargets']])
 
 
 		#Instant Revive tracking of downed healing


### PR DESCRIPTION
This is a similar change to the other stats that we changed that we using 'all' stats, instead of 'target' stats.

I checked the log outputs against the Offensive Stats panel that we get on dps.reports. Currently the 'statsAll' is replicating the 'All' panel, but I think we want to be using the 'target' stats here too.

I ended up finding this because I found scenarios where Crit attack % was much lower than expected for the class build. When I looked into it I found that, even though the `statsAll` explicitly seems to separate out critable attacks, it was still including attacks against non enemies.

I found scenarios where we had a power scrapper that had 90+% crits against targets, but only 30% 'all' crit chance, because they were sitting flamethrower against a gate 😂  ( i think it was a gate at least)