### PR TITLE
Allow loading compressed JSON.gz files, unzip on the fly

### DIFF
--- a/TW5_parse_top_stats_monthly_tools.py
+++ b/TW5_parse_top_stats_monthly_tools.py
@@ -32,6 +32,7 @@ import jsons
 import math
 import requests
 import datetime
+import gzip
 from collections import OrderedDict
 
 from GW2_Color_Scheme import ProfessionColor
@@ -1355,7 +1356,7 @@ def collect_stat_data(args, config, log, anonymize=False):
 		# skip files of incorrect filetype
 		file_start, file_extension = os.path.splitext(filename)
 		#if args.filetype not in file_extension or "top_stats" in file_start:
-		if 'json' not in file_extension or "top_stats" in file_start:
+		if file_extension not in ['.json', '.gz'] or "top_stats" in file_start:
 			continue
 
 		print_string = "parsing "+filename
@@ -1370,8 +1371,12 @@ def collect_stat_data(args, config, log, anonymize=False):
 #            # get fight stats
 #            fight, players_running_healing_addon = get_stats_from_fight_xml(xml_root, config, log)
 #        else: # filetype == "json"
-		json_datafile = open(file_path, encoding='utf-8')
-		json_data = json.load(json_datafile)
+		if file_extension == '.gz':
+			with gzip.open(file_path, mode="r") as f:
+				json_data = json.loads(f.read().decode('utf-8'))
+		else:
+			json_datafile = open(file_path, encoding='utf-8')
+			json_data = json.load(json_datafile)
 		# get fight stats
 		fight, players_running_healing_addon, squad_offensive, squad_Control, enemy_Control, enemy_Control_Player, downed_Healing, uptime_Table, auras_TableIn, auras_TableOut, Death_OnTag, DPS_List = get_stats_from_fight_json(json_data, config, log)
 			

--- a/TW5_parse_top_stats_tools.py
+++ b/TW5_parse_top_stats_tools.py
@@ -32,6 +32,7 @@ import jsons
 import math
 import requests
 import datetime
+import gzip
 from collections import OrderedDict
 
 from GW2_Color_Scheme import ProfessionColor
@@ -1446,7 +1447,7 @@ def collect_stat_data(args, config, log, anonymize=False):
 		# skip files of incorrect filetype
 		file_start, file_extension = os.path.splitext(filename)
 		#if args.filetype not in file_extension or "top_stats" in file_start:
-		if 'json' not in file_extension or "top_stats" in file_start:
+		if file_extension not in ['.json', '.gz'] or "top_stats" in file_start:
 			continue
 
 		print_string = "parsing "+filename
@@ -1461,8 +1462,12 @@ def collect_stat_data(args, config, log, anonymize=False):
 #            # get fight stats
 #            fight, players_running_healing_addon = get_stats_from_fight_xml(xml_root, config, log)
 #        else: # filetype == "json"
-		json_datafile = open(file_path, encoding='utf-8')
-		json_data = json.load(json_datafile)
+		if file_extension == '.gz':
+			with gzip.open(file_path, mode="r") as f:
+				json_data = json.loads(f.read().decode('utf-8'))
+		else:
+			json_datafile = open(file_path, encoding='utf-8')
+			json_data = json.load(json_datafile)
 		# get fight stats
 		fight, players_running_healing_addon, squad_offensive, squad_Control, enemy_Control, enemy_Control_Player, downed_Healing, uptime_Table, auras_TableIn, auras_TableOut, Death_OnTag, DPS_List, DPSStats = get_stats_from_fight_json(json_data, config, log)
 			


### PR DESCRIPTION
Not sure about you, but all these parsed logs are starting to take up a lot of space. I find myself deleting them and then reparsing them.

I realized that Elite Insights has an option to output compressed logs, and unzipping them on the fly is really quick.

This adds support for them, but you can still use the uncompressed logs too

To turn on compressed logs you do it here:

![Compress](https://user-images.githubusercontent.com/116599399/210918077-a082750d-c6f2-4fed-84c1-d4fc534752eb.PNG)
