### PR TITLE
Recalculate boon generation fixing squad weights

### DIFF
--- a/TW5_parse_top_stats_tools.py
+++ b/TW5_parse_top_stats_tools.py
@@ -1355,7 +1355,8 @@ def write_sorted_total(players, top_total_players, config, total_fight_duration,
 		if stat == 'iol':
 			print_string += " !FightTime Avg| !CombatTime Avg|"
 		else:
-			print_string += " !Squad Avg| !Group Avg| !Self Avg|"
+			per_sec_name = stat[:1].upper() + "PS"
+			print_string += f" !Squad {per_sec_name}| !Group {per_sec_name}| !Self {per_sec_name}|"
 	if stat == 'dmg':
 		print_string += " !FightTime DPS| !CombatTime DPS|"
 	if stat == 'heal':
@@ -1416,14 +1417,14 @@ def write_sorted_total(players, top_total_players, config, total_fight_duration,
 			print_string += " "+"{:.2f}".format(round(player.average_stats[stat], 2))+"| "+"{:.2f}".format(round((player.total_stats[stat]/combat_Time)*100, 2))+"|"
 		elif stat in config.buffs_stacking_duration:
 			print_string += " "+my_value(round(player.total_stats[stat]))+"|"
-			print_string += " "+'<span data-tooltip="'+my_value(round(player.total_stats[stat]))+' seconds of generation">'+"{:.2f}".format(round(player.average_stats[stat], 2))+'/sec</span>|'
-			print_string += " "+'<span data-tooltip="'+my_value(round(player.total_stats_group[stat]))+' seconds of generation">'+"{:.2f}".format(round(player.total_stats_group[stat]/player.duration_fights_present, 2))+'/sec</span>|'
-			print_string += " "+'<span data-tooltip="'+my_value(round(player.total_stats_self[stat]))+' seconds of generation">'+"{:.2f}".format(round(player.total_stats_self[stat]/player.duration_fights_present, 2))+'/sec</span>|'
+			print_string += " "+'<span data-tooltip="'+my_value(round(player.total_stats[stat]))+' seconds of generation">'+"{:.2f}".format(round(player.average_stats[stat], 2))+'</span>|'
+			print_string += " "+'<span data-tooltip="'+my_value(round(player.total_stats_group[stat]))+' seconds of generation">'+"{:.2f}".format(round(player.total_stats_group[stat]/player.duration_fights_present, 2))+'</span>|'
+			print_string += " "+'<span data-tooltip="'+my_value(round(player.total_stats_self[stat]))+' seconds of generation">'+"{:.2f}".format(round(player.total_stats_self[stat]/player.duration_fights_present, 2))+'</span>|'
 		elif stat in config.buffs_stacking_intensity:
 			print_string += " "+my_value(round(player.total_stats[stat]))+"|"
-			print_string += " "+'<span data-tooltip="'+my_value(round(player.total_stats[stat]))+' stacks of generation">'+"{:.2f}".format(round(player.average_stats[stat], 2))+'/sec</span>|'
-			print_string += " "+'<span data-tooltip="'+my_value(round(player.total_stats_group[stat]))+' stacks of generation">'+"{:.2f}".format(round(player.total_stats_group[stat]/player.duration_fights_present, 2))+'/sec</span>|'
-			print_string += " "+'<span data-tooltip="'+my_value(round(player.total_stats_self[stat]))+' stacks of generation">'+"{:.2f}".format(round(player.total_stats_self[stat]/player.duration_fights_present, 2))+'/sec</span>|'
+			print_string += " "+'<span data-tooltip="'+my_value(round(player.total_stats[stat]))+' stacks of generation">'+"{:.2f}".format(round(player.average_stats[stat], 2))+'</span>|'
+			print_string += " "+'<span data-tooltip="'+my_value(round(player.total_stats_group[stat]))+' stacks of generation">'+"{:.2f}".format(round(player.total_stats_group[stat]/player.duration_fights_present, 2))+'</span>|'
+			print_string += " "+'<span data-tooltip="'+my_value(round(player.total_stats_self[stat]))+' stacks of generation">'+"{:.2f}".format(round(player.total_stats_self[stat]/player.duration_fights_present, 2))+'</span>|'
 		else:
 			print_string += " "+my_value(round(player.total_stats[stat]))+"|"
 		myprint(output_file, print_string)


### PR DESCRIPTION
I know we are already talking about this on Discord, but opened this up to make sure we were looking at the same thing :D

I know we would need to make similar changes to the monthly script and probably some other things, but wanted to push what I had so far.

----

Currently we get the boon generation numbers by combining the squad generation from each fight.

This leads to accidentally having the number of people in the squad effect the generation amount of a boon. Having more people in squad will make it look like less of a boon is generated.

In order to fix this we need to unweight the boon generation durations before tracking them in `total_stats`, and we also need so new weighted durations to later calculate the `avg_stats` again.

We've also changed the way we display durations in the tables. Currently all the boon tables show squad generation. Squad generation is better than group generation, because we want to know how much of your boons are going to everyone. So we've reweighted the table to represent the % of uptime you provide to your group members (4 other players).

I also added a new column for "On Group %" which represents the % of boon generation that was within a players party