### PR TITLE
Add config options to sort tables by average by default

### DIFF
--- a/TW5_parse_top_stats_detailed.py
+++ b/TW5_parse_top_stats_detailed.py
@@ -430,7 +430,12 @@ if __name__ == '__main__':
 			else:
 				myprint(output, '\n<div class="flex-row">\n    <div class="flex-col border">\n')
 				myprint(output, '<div style="overflow-x:auto;">\n\n')
-				top_total_stat_players[stat] = get_and_write_sorted_total(players, config, total_fight_duration, stat, output)
+				if config.player_sorting_stat_type == 'average':
+					top_average_stat_players[stat] = get_and_write_sorted_total_by_average(players, config, total_fight_duration, stat, output)
+					top_total_stat_players[stat] = get_top_players(players, config, stat, StatType.TOTAL)
+				else:
+					top_total_stat_players[stat] = get_and_write_sorted_total(players, config, total_fight_duration, stat, output)
+					top_average_stat_players[stat] = get_top_players(players, config, stat, StatType.AVERAGE)	
 				myprint(output, '\n\n\n\n')
 				top_consistent_stat_players[stat] = get_and_write_sorted_top_consistent(players, config, num_used_fights, stat, output)			
 				myprint(output, '\n\n</div>\n\n')
@@ -1500,6 +1505,7 @@ if __name__ == '__main__':
 	myprint(output, "\n</$reveal>\n")     
 	# end Ch5Ca Burst Damage
 
+	top_players_by_stat = top_average_stat_players if config.player_sorting_stat_type == 'average' else top_total_stat_players
 	for stat in config.stats_to_compute:
 		skip_boxplot_charts = ['deaths', 'iol', 'stealth', 'HiS']
 		#boxplot_Stats = ['stability',  'protection', 'aegis', 'might', 'fury', 'resistance', 'resolution', 'quickness', 'swiftness', 'alacrity', 'vigor', 'regeneration', 'res', 'kills', 'downs', 'swaps', 'dmg', 'Pdmg', 'Cdmg', 'rips', 'cleanses', 'superspeed', 'barrierDamage']
@@ -1514,34 +1520,34 @@ if __name__ == '__main__':
 		#		#write_stats_chart(players, top_average_stat_players[stat], stat, myDate, args.input_directory, config)
 		#		write_stats_box_plots(players, top_average_stat_players[stat], stat, ProfessionColor, myDate, args.input_directory, config)
 		elif stat == 'heal' and found_healing:
-			write_stats_xls(players, top_total_stat_players[stat], stat, args.xls_output_filename)
+			write_stats_xls(players, top_players_by_stat[stat], stat, args.xls_output_filename)
 			if config.charts:
-				#write_stats_chart(players, top_total_stat_players[stat], stat, myDate, args.input_directory, config)
-				write_stats_box_plots(players, top_total_stat_players[stat], stat, ProfessionColor, myDate, args.input_directory, config)
+				#write_stats_chart(players, top_players_by_stat[stat], stat, myDate, args.input_directory, config)
+				write_stats_box_plots(players, top_players_by_stat[stat], stat, ProfessionColor, myDate, args.input_directory, config)
 		elif stat == 'barrier' and found_barrier:
-			write_stats_xls(players, top_total_stat_players[stat], stat, args.xls_output_filename)
+			write_stats_xls(players, top_players_by_stat[stat], stat, args.xls_output_filename)
 			if config.charts:
-				#write_stats_chart(players, top_total_stat_players[stat], stat, myDate, args.input_directory, config)
-				write_stats_box_plots(players, top_total_stat_players[stat], stat, ProfessionColor, myDate, args.input_directory, config)
+				#write_stats_chart(players, top_players_by_stat[stat], stat, myDate, args.input_directory, config)
+				write_stats_box_plots(players, top_players_by_stat[stat], stat, ProfessionColor, myDate, args.input_directory, config)
 		#elif stat == 'deaths':
 		#	write_stats_xls(players, top_consistent_stat_players[stat], stat, args.xls_output_filename)
 		#	if config.charts:
 		#		write_stats_chart(players, top_consistent_stat_players[stat], stat, myDate, args.input_directory, config)
 		elif stat not in skip_boxplot_charts:
-			write_stats_xls(players, top_total_stat_players[stat], stat, args.xls_output_filename)
+			write_stats_xls(players, top_players_by_stat[stat], stat, args.xls_output_filename)
 			if config.charts:
-				#write_stats_chart(players, top_total_stat_players[stat], stat, myDate, args.input_directory, config)
-				write_stats_box_plots(players, top_total_stat_players[stat], stat, ProfessionColor, myDate, args.input_directory, config)
+				#write_stats_chart(players, top_players_by_stat[stat], stat, myDate, args.input_directory, config)
+				write_stats_box_plots(players, top_players_by_stat[stat], stat, ProfessionColor, myDate, args.input_directory, config)
 		else:
-			write_stats_xls(players, top_total_stat_players[stat], stat, args.xls_output_filename)
+			write_stats_xls(players, top_players_by_stat[stat], stat, args.xls_output_filename)
 			if config.charts:
-				write_stats_chart(players, top_total_stat_players[stat], stat, myDate, args.input_directory, config)
-				#write_stats_box_plots(players, top_total_stat_players[stat], stat, ProfessionColor, myDate, args.input_directory, config)
+				write_stats_chart(players, top_players_by_stat[stat], stat, myDate, args.input_directory, config)
+				#write_stats_box_plots(players, top_players_by_stat[stat], stat, ProfessionColor, myDate, args.input_directory, config)
 		if stat == 'rips' or stat == 'cleanses' or stat == 'stability':
-			supportCount = write_support_xls(players, top_total_stat_players[stat], stat, args.xls_output_filename, supportCount)
+			supportCount = write_support_xls(players, top_players_by_stat[stat], stat, args.xls_output_filename, supportCount)
 
 	#write out Bubble Charts and Box_Plots
-	write_bubble_charts(players, top_total_stat_players[stat], squad_Control, myDate, args.input_directory)
+	write_bubble_charts(players, top_players_by_stat[stat], squad_Control, myDate, args.input_directory)
 	write_spike_damage_heatmap(squad_damage_output, myDate, args.input_directory)
 	write_box_plot_charts(DPS_List, myDate, args.input_directory, "DPS")
 	write_box_plot_charts(SPS_List, myDate, args.input_directory, "SPS")

--- a/TW5_parse_top_stats_detailed.py
+++ b/TW5_parse_top_stats_detailed.py
@@ -465,7 +465,12 @@ if __name__ == '__main__':
 		myprint(output,'<$reveal type="match" state="$:/state/curAuras-Out" text="'+config.stat_names[stat]+'">')
 		myprint(output, '\n<div class="flex-row">\n    <div class="flex-col border">\n')
 		myprint(output, '<div style="overflow-x:auto;">\n\n')
-		top_total_stat_players[stat] = get_and_write_sorted_total(players, config, total_fight_duration, stat, output)
+		if config.player_sorting_stat_type == 'average':
+			top_average_stat_players[stat] = get_and_write_sorted_total_by_average(players, config, total_fight_duration, stat, output)
+			top_total_stat_players[stat] = get_top_players(players, config, stat, StatType.TOTAL)
+		else:
+			top_total_stat_players[stat] = get_and_write_sorted_total(players, config, total_fight_duration, stat, output)
+			top_average_stat_players[stat] = get_top_players(players, config, stat, StatType.AVERAGE)
 		myprint(output, '\n\n')
 		top_consistent_stat_players[stat] = get_and_write_sorted_top_consistent(players, config, num_used_fights, stat, output)			
 		myprint(output, '\n</div>')
@@ -475,7 +480,6 @@ if __name__ == '__main__':
 		myprint(output, '<$echarts $text={{'+fileDate.strftime("%Y%m%d%H%M")+'_'+stat+'_ChartData}} $height="800px" $theme="dark"/>')
 		myprint(output, '\n</div>')
 		myprint(output, '\n</div></div>\n')
-		top_average_stat_players[stat] = get_top_players(players, config, stat, StatType.AVERAGE)
 		top_percentage_stat_players[stat],comparison_val = get_top_percentage_players(players, config, stat, StatType.PERCENTAGE, num_used_fights, top_consistent_stat_players[stat], top_total_stat_players[stat], list(), list())
 		myprint(output, "</$reveal>\n")
 	myprint(output, "</$reveal>\n")	
@@ -508,7 +512,12 @@ if __name__ == '__main__':
 		myprint(output,'<$reveal type="match" state="$:/state/curDefense" text="'+config.stat_names[stat]+'">')
 		myprint(output, '\n<div class="flex-row">\n    <div class="flex-col border">\n')
 		myprint(output, '<div style="overflow-x:auto;">\n\n')
-		top_total_stat_players[stat] = get_and_write_sorted_total(players, config, total_fight_duration, stat, output)
+		if config.player_sorting_stat_type == 'average':
+			top_average_stat_players[stat] = get_and_write_sorted_total_by_average(players, config, total_fight_duration, stat, output)
+			top_total_stat_players[stat] = get_top_players(players, config, stat, StatType.TOTAL)
+		else:
+			top_total_stat_players[stat] = get_and_write_sorted_total(players, config, total_fight_duration, stat, output)
+			top_average_stat_players[stat] = get_top_players(players, config, stat, StatType.AVERAGE)
 		myprint(output, '\n\n')
 		top_consistent_stat_players[stat] = get_and_write_sorted_top_consistent(players, config, num_used_fights, stat, output)			
 		myprint(output, '\n</div>')
@@ -518,7 +527,6 @@ if __name__ == '__main__':
 		myprint(output, '<$echarts $text={{'+fileDate.strftime("%Y%m%d%H%M")+'_'+stat+'_ChartData}} $height="800px" $theme="dark"/>')
 		myprint(output, '\n</div>')
 		myprint(output, '\n</div></div>\n')
-		top_average_stat_players[stat] = get_top_players(players, config, stat, StatType.AVERAGE)
 		top_percentage_stat_players[stat],comparison_val = get_top_percentage_players(players, config, stat, StatType.PERCENTAGE, num_used_fights, top_consistent_stat_players[stat], top_total_stat_players[stat], list(), list())
 		myprint(output, "</$reveal>\n")
 	myprint(output, "</$reveal>\n")	

--- a/TW5_parse_top_stats_tools.py
+++ b/TW5_parse_top_stats_tools.py
@@ -1468,20 +1468,25 @@ def write_sorted_total(players, top_total_players, config, total_fight_duration,
 		else:
 			per_sec_name = stat[:1].upper() + "PS"
 			print_string += f" !Squad {per_sec_name}| !Group {per_sec_name}| !Self {per_sec_name}|"
-	if stat == 'dmg':
+	elif stat == 'dmg':
 		print_string += " !FightTime DPS| !CombatTime DPS|  !Damage/Enemy|   !Wt. DPS/Enemy|"
-	if stat == 'heal':
+	elif stat == 'heal':
 		print_string += " !Squad HPS| !Group HPS| !Self HPS|"
-	if stat == 'rips' or stat == 'rips-In':
+	elif stat == 'rips' or stat == 'rips-In':
 		print_string += " !FightTime SPS| !CombatTime SPS|"
-	if stat == 'cleanses' or stat == 'cleanses-In':
+	elif stat == 'cleanses' or stat == 'cleanses-In':
 		print_string += " !FightTime CPS| !CombatTime CPS|"
-	if stat == 'barrier':
+	elif stat == 'barrier':
 		print_string += " !Squad BPS| !Group BPS| !Self BPS|"
-	if stat == 'downs':
+	elif stat == 'downs':
 		print_string += " !FightTime Downs/Min| !CombatTime Downs/Min|"
-	if stat == 'kills':
+	elif stat == 'kills':
 		print_string += " !FightTime Kills/Min| !CombatTime Kills/Min|"
+	else:
+		if stat in ['Pdmg', 'Cdmg', 'dmg_taken', 'barrierDamage', 'cleansesIn', 'ripsIn']:
+			print_string += " !Per sec avg|"
+		else:
+			print_string += " !Per min avg|"
 	print_string += "h"
 	myprint(output_file, print_string)    
 
@@ -1574,6 +1579,10 @@ def write_sorted_total(players, top_total_players, config, total_fight_duration,
 			print_string += " "+'<span data-tooltip="'+my_value(round(stat_Generated_Self, 4))+' Self Generation">'+"{:.2f}".format(round(player.total_stats_self[stat]/player.duration_fights_present, 2))+'</span>|'
 		else:
 			print_string += " "+my_value(round(player.total_stats[stat]))+"|"
+			if stat in ['Pdmg', 'Cdmg', 'dmg_taken', 'barrierDamage', 'cleansesIn', 'ripsIn', 'deaths']:
+				print_string += " "+"{:.2f}".format(round(player.average_stats[stat], 2))+"|"
+			else:
+				print_string += " "+"{:.2f}".format(round(player.average_stats[stat] * 60.0, 2))+"|"
 		myprint(output_file, print_string)
 		last_val = player.total_stats[stat]
 	myprint(output_file, "\n")

--- a/TW5_parse_top_stats_tools.py
+++ b/TW5_parse_top_stats_tools.py
@@ -582,8 +582,11 @@ def get_top_players(players, config, stat, total_or_consistent_or_average):
 	elif total_or_consistent_or_average == StatType.CONSISTENT:
 		percentage = float(config.portion_of_top_for_consistent)
 		sorted_index = sort_players_by_consistency(players, stat)
-	elif total_or_consistent_or_average == StatType.AVERAGE:
+	elif total_or_consistent_or_average == StatType.AVERAGE and stat != 'dmg':
 		percentage = float(config.portion_of_top_for_average)
+		sorted_index = sort_players_by_average(players, stat)        
+	elif total_or_consistent_or_average == StatType.AVERAGE and stat == 'dmg':
+		percentage = float(config.portion_of_topDamage_for_total)
 		sorted_index = sort_players_by_average(players, stat)        
 	else:
 		print("ERROR: Called get_top_players for stats that are not total or consistent")

--- a/parser_configs/TW5_parser_config_detailed.py
+++ b/parser_configs/TW5_parser_config_detailed.py
@@ -30,6 +30,9 @@ num_players_listed = {'dmg': 100, 'Pdmg': 50, 'Cdmg': 50, 'iol': 50,'rips': 50, 
 # What portion (%) of are considered to be "top" in each fight for each stat?
 num_players_considered_top_percentage = 5
 
+# For the initial sorting of tables: 'total' or 'average'
+player_sorting_stat_type = 'average'
+
 # For what portion of all fights does a player need to be there to be considered for "consistency percentage" awards?
 attendance_percentage_for_percentage = 50
 # For what portion of all fights does a player need to be there to be considered for "late but great" awards?
@@ -38,6 +41,8 @@ attendance_percentage_for_late = 50
 attendance_percentage_for_buildswap = 30
 # For what portion of all fights does a player need to be there to be considered for "top average" awards? 
 attendance_percentage_for_average = 33
+# For what portion of all fights does a player need to be there to be considered at all
+attendance_percentage_for_top = 1
 
 # What portion of the top total player stat does someone need to reach to be considered for total awards?
 percentage_of_top_for_consistent = 10
@@ -45,6 +50,8 @@ percentage_of_top_for_consistent = 10
 percentage_of_top_for_total = 10
 # What portion of the total stat of the top consistent player does someone need to reach to be considered for consistency awards?
 percentage_of_topDamage_for_total = 0
+# What portion of the total stat of the top consistent player does someone need to reach to be considered for consistency awards?
+percentage_of_top_for_average = 10
 # What portion of the percentage the top consistent player reached top does someone need to reach to be considered for percentage awards?
 percentage_of_top_for_percentage = 10
 # What portion of the percentage the top consistent player reached top does someone need to reach to be considered for late but great awards?


### PR DESCRIPTION
Add config options to sort tables by average by default and percentage of top to include.

Also added a minimum attendance cutoff. This is because when we sort by averages, we find some players with incredibly low attendance, but a high average. I set the cutoff very low to start